### PR TITLE
Doesn't work on a white terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Push an existing repository
   git push -u origin master
 ```
 
+__Example:__
+
+List issues in current repo, write to file as json
+
+```
+$ ngh issues --format json > issues.json
+```
+
 ## API
 
 The actual client can be found in `index.js`.

--- a/bin/commands/list-issues.js
+++ b/bin/commands/list-issues.js
@@ -1,23 +1,7 @@
 var config  = require('../../config');
 var utils   = require('../../lib/utils');
 var github  = require('../../');
-
-var tmpl = function( issue, i, meta ){
-  var stripe = utils.color.bgXterm( i % 2 === 0 ? 232 : 233 );
-
-  return stripe([
-    '#', utils.padRight( issue.number.toString(), meta.greatestLengths.number )
-  , ' - ', issue.title
-  , utils.padding(
-      Math.abs( process.stdout.columns - issue.title.length - meta.greatestLengths.number - 3 )
-    )
-  , '\n', utils.padding( meta.greatestLengths.number + 5 )
-  , utils.color.xterm(249)( utils.color.underline( issue.html_url ) )
-  , utils.padding(
-      Math.abs( process.stdout.columns - issue.html_url.length - meta.greatestLengths.number - 3 )
-    )
-  ].join(''));
-};
+var tmpl    = require('../../lib/tmpl');
 
 module.exports = function( orgname, options ){
   var gh = github.createClient();
@@ -29,7 +13,15 @@ module.exports = function( orgname, options ){
 
   if ( typeof orgname === 'string' )
   if ( orgname.indexOf('/') === -1 ){
-    throw new Error('Invalid organization/name format');
+    throw new Error('Invalid `organization`/`name` combination');
+  }
+
+  options = utils.defaults( options || {}, {
+    format: 'striped-table'
+  });
+
+  if ( !(options.format in tmpl.issues) ){
+    throw new Error('Invalid option: `format`');
   }
 
   utils.async.series([
@@ -61,29 +53,7 @@ module.exports = function( orgname, options ){
           throw error;
         }
 
-        var meta = {};
-
-        meta.greatestLengths = {};
-
-        issues.forEach( function( issue ){
-          utils.truncate( issue.title, 40, '...' );
-        });
-
-        ['number', 'title', 'html_url'].forEach( function( k ){
-          meta.greatestLengths[ k ] = issues.map( function( issue ){
-            return issue[ k ].toString().length;
-          }).reduce( function( a, b ){
-            return a > b ? a : b;
-          });
-        });
-
-        console.log('');
-        console.log( new Array( process.stdout.columns ).join('=') );
-        issues.forEach( function( issue, i ){
-          console.log( tmpl( issue, i, meta ) );
-        });
-        console.log( new Array( process.stdout.columns ).join('=') );
-        console.log('');
+        process.stdout.write( tmpl.issues[ options.format ]({ issues: issues }) );
       });
     }
   ]);

--- a/bin/ngh
+++ b/bin/ngh
@@ -74,6 +74,7 @@ program
   .option('-o, --organization <organization>', 'Repository owner/organization')
   .option('-r, --repo <repo_name>', 'Repository name')
   .option('--open', 'Opens the issue in your web browser afterwards')
+  .option('--format <format>', 'Format of the output')
   .action( require('./commands/list-issues') );
 
 program

--- a/lib/tmpl.js
+++ b/lib/tmpl.js
@@ -1,0 +1,55 @@
+var tmpl    = module.exports = {};
+
+var utils   = require('./utils');
+
+tmpl.issues = {};
+
+tmpl.issues['striped-table'] = function( data ){
+  var row = function( issue, i, meta ){
+    var stripe = utils.color.bgXterm( i % 2 === 0 ? 232 : 233 );
+    var title = utils.truncate( issue.title, 40, '...' );
+    
+    var firstLine = [
+      '#', utils.padRight( issue.number.toString(), meta.greatestLengths.number )
+    , ' - ', issue.title
+    ].join('');
+
+    return stripe([
+      utils.color.white( firstLine )
+    , utils.padding(
+        Math.abs( process.stdout.columns - issue.title.length - meta.greatestLengths.number - 3 )
+      )
+    , '\n', utils.padding( meta.greatestLengths.number + 5 )
+    , utils.color.xterm(249)( utils.color.underline( issue.html_url ) )
+    , utils.padding(
+        Math.abs( process.stdout.columns - issue.html_url.length - meta.greatestLengths.number - 3 )
+      )
+    ].join(''));
+  };
+
+  var out = [], meta = {};
+
+  meta.greatestLengths = {};
+
+  ['number', 'title', 'html_url'].forEach( function( k ){
+    meta.greatestLengths[ k ] = data.issues.map( function( issue ){
+      return issue[ k ].toString().length;
+    }).reduce( function( a, b ){
+      return a > b ? a : b;
+    });
+  });
+
+  out.push('')
+  out.push( new Array( process.stdout.columns ).join('=') );
+  data.issues.forEach( function( issue, i ){
+    out.push( row( issue, i, meta ) );
+  });
+  out.push( new Array( process.stdout.columns ).join('=') );
+  out.push('')
+
+  return out.join('\n');
+};
+
+tmpl.issues['json'] = function( data ){
+  return JSON.stringify( data.issues );
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,10 +4,13 @@ var fs          = require('fs');
 var child       = require('child_process');
 var config      = require('../config');
 
+utils._         = require('lodash');
 utils.async     = require('async');
 utils.editorIn  = require('editor-in');
 utils.color     = require('cli-color');
 utils.ghauth    = require('ghauth');
+
+utils._.extend( utils, utils._ );
 
 utils.getCurrentRepositoryUrl = function( callback ){
   var command = ['git', 'config', '--get', 'remote.origin.url'].join(' ');

--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
     "mocha": "~1.18.2"
   },
   "dependencies": {
-    "commander": "^2.2.0",
-    "request": "^2.34.0",
     "async": "~0.8.0",
-    "editor-in": "~0.2.0",
     "cli-color": "~0.3.2",
-    "ghauth": "~0.1.1"
+    "commander": "^2.2.0",
+    "editor-in": "~0.2.0",
+    "ghauth": "~0.1.1",
+    "lodash": "^2.4.1",
+    "request": "^2.34.0"
   }
 }


### PR DESCRIPTION
The default Terminal in the Mac OS is black text on a white background. `ngh --help` works, but `ngh issues` outputs a black background, so the black text can't be read.
